### PR TITLE
The s3 signingMethod parameter supports customization.

### DIFF
--- a/oss/oss.go
+++ b/oss/oss.go
@@ -67,6 +67,7 @@ type S3 struct {
 	Bucket       string
 	Region       string
 	UseIamRole   bool
+	SignatureVersion string
 }
 
 func (s *S3) Validate() error {

--- a/oss/s3/s3.go
+++ b/oss/s3/s3.go
@@ -127,6 +127,8 @@ func normalizeSignatureVersion(version string) string {
 	switch strings.ToLower(version) {
 	case "unsigned":
 		return ""
+	case "":
+		return "v4"  // 默认使用 v4
 	default:
 		return version
 	}

--- a/oss/s3/s3.go
+++ b/oss/s3/s3.go
@@ -38,6 +38,7 @@ func NewS3Storage(args oss.OSSArgs) (oss.OSS, error) {
 	usePathStyle := args.S3.UsePathStyle
 	bucket := args.S3.Bucket
 	useIamRole := args.S3.UseIamRole
+	signatureVersion := args.S3.SignatureVersion
 
 	var cfg aws.Config
 	var client *s3.Client
@@ -49,14 +50,22 @@ func NewS3Storage(args oss.OSSArgs) (oss.OSS, error) {
 				config.WithRegion(region),
 			)
 		} else {
-			cfg, err = config.LoadDefaultConfig(
-				context.TODO(),
-				config.WithRegion(region),
-				config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			// 处理签名版本和凭证
+			var credProvider aws.CredentialsProvider
+			if strings.ToLower(signatureVersion) == "unsigned" {
+				credProvider = aws.AnonymousCredentials{}
+			} else {
+				credProvider = credentials.NewStaticCredentialsProvider(
 					ak,
 					sk,
 					"",
-				)),
+				)
+			}
+
+			cfg, err = config.LoadDefaultConfig(
+				context.TODO(),
+				config.WithRegion(region),
+				config.WithCredentialsProvider(credProvider),
 			)
 		}
 		if err != nil {
@@ -70,19 +79,26 @@ func NewS3Storage(args oss.OSSArgs) (oss.OSS, error) {
 			options.UsePathStyle = usePathStyle
 		})
 	} else {
+		var credProvider aws.CredentialsProvider
+		if strings.ToLower(signatureVersion) == "unsigned" {
+			credProvider = aws.AnonymousCredentials{}
+		} else {
+			credProvider = credentials.NewStaticCredentialsProvider(ak, sk, "")
+		}
 		client = s3.New(s3.Options{
-			Credentials:  credentials.NewStaticCredentialsProvider(ak, sk, ""),
+			Credentials:  credProvider,
 			UsePathStyle: usePathStyle,
 			Region:       region,
 			EndpointResolver: s3.EndpointResolverFunc(
 				func(region string, options s3.EndpointResolverOptions) (aws.Endpoint, error) {
+					signingMethod := normalizeSignatureVersion(signatureVersion)
 					return aws.Endpoint{
 						URL:               endpoint,
 						HostnameImmutable: false,
 						SigningName:       "s3",
 						PartitionID:       "aws",
 						SigningRegion:     region,
-						SigningMethod:     "v4",
+						SigningMethod:     signingMethod,
 						Source:            aws.EndpointSourceCustom,
 					}, nil
 				}),
@@ -105,6 +121,15 @@ func NewS3Storage(args oss.OSSArgs) (oss.OSS, error) {
 		}
 	}
 	return &S3Storage{bucket: bucket, client: client}, nil
+}
+
+func normalizeSignatureVersion(version string) string {
+	switch strings.ToLower(version) {
+	case "unsigned":
+		return ""
+	default:
+		return version
+	}
 }
 
 func (s *S3Storage) Save(key string, data []byte) error {


### PR DESCRIPTION
# Enhancements to S3 Storage Configuration

This update improves the S3 storage configuration in the `oss/oss.go` and `oss/s3/s3.go` files by introducing support for the `SignatureVersion` parameter. The changes include:

- Added `SignatureVersion string` to the `s3` struct in `oss/oss.go` to allow specification of the signature version.
- Updated `NewS3Storage` in `oss/s3/s3.go` to accept and pass the `SignatureVersion` from the input arguments.
- Implemented conditional credential handling based on `SignatureVersion`:
  - If set to `'unsigned'`, uses `aws.AnonymousCredentials`.
  - Otherwise, defaults to `aws.NewStaticCredentialsProvider` with the provided credentials.
- Introduced a `normalizeSignatureVersion` function to standardize input values, mapping `'unsigned'` to `""` and defaulting to `"v4"` for other cases.
- Enhanced the endpoint resolver to incorporate the `SignatureVersion` and `SigningMethod` for customized S3 operations.

These modifications provide greater flexibility and control over S3 storage configurations, supporting both unsigned access and standard signed requests.